### PR TITLE
Fixed bug w/ extendsFrom when target and base classes don't exist

### DIFF
--- a/es6/decorators/ModelProperties.js
+++ b/es6/decorators/ModelProperties.js
@@ -130,7 +130,7 @@ function extractBits(property) {
         // If the value of the model is already the type of class we expect
         // we do not need to do any processing and we can just grab it and
         // go.
-        if (extendsFrom(model[modelName], typeClass)) {
+        if (model[modelName] && extendsFrom(model[modelName], typeClass)) {
           val = model[modelName]
         }
 

--- a/es6/types.js
+++ b/es6/types.js
@@ -305,6 +305,14 @@ export function extendsFrom(
  RootClass: Function,
  enforceClasses: boolean = false
 ): boolean {
+  if (!TestedClass || !RootClass) {
+    return false;
+  }
+
+  if (TestedClass === RootClass) {
+    return true;
+  }
+
   TestedClass = TestedClass.constructor && typeof TestedClass !== 'function'
     ? TestedClass.constructor : TestedClass
 

--- a/test/decorators.test.js
+++ b/test/decorators.test.js
@@ -350,7 +350,8 @@ describe('DIRECT_TYPES', () => {
     const peep = new Person(model2, null, {autoProps: false})
 
     expect(typeOf(peep.job)).toBe(Job.name)
-    expect(peep.job).toBe(job)
+    expect(peep.job === model2.job).toBe(true);
+    expect(peep.job).toEqual(job)
     expect(peep.name).toEqual(answer1)
     expect(peep.model.job.model.company).toEqual(answer4)
     expect(peep.model.job.company).toEqual(answer5)

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,9 +2,11 @@ import { stat } from 'fs'
 import {
   getLatticePrefs,
   Deferred,
-  promisify
+  promisify,
+  types
 } from '../es6/lattice'
 
+const { extendsFrom } = types;
 
 describe('getLatticePrefs should combine defaults with custom value', () => {
   it('should pick up local package.json "lattice" settings', () => {
@@ -142,3 +144,30 @@ describe('Sample promisify should work similar to node 8+ version', () => {
     }
   })
 })
+
+describe('extendsFrom', () => {
+  class A {}
+  class B extends A {}
+  class C {}
+  class D extends B {}
+
+  it('should determine if a class extends another', () => {
+    expect(extendsFrom(C, A)).toBe(false);
+    expect(extendsFrom(B, A)).toBe(true);
+    expect(extendsFrom(D, A)).toBe(true);
+  });
+
+  it('should not throw errors w/ nulls', () => {
+    expect(() => {
+      extendsFrom(null, A);
+    }).not.toThrow();
+
+    expect(() => {
+      extendsFrom(A, null);
+    }).not.toThrow();
+
+    expect(() => {
+      extendsFrom(null, null);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
`extendsFrom` had a bug where it assumed that the target class and the root
class always exist, so accessing their constructors threw errors.

Added some unit tests.

![img](https://media3.giphy.com/media/xThuW6sWCGbpZMpX7a/giphy.gif)