### PR TITLE
Passing along res through to patchFn

### DIFF
--- a/es6/GQLExpressMiddleware.js
+++ b/es6/GQLExpressMiddleware.js
@@ -254,10 +254,10 @@ export class GQLExpressMiddleware extends EventEmitter
     },
     patchFn: ?Function = null
   ): Function {
-    const optsFn = async (req: mixed) => {
+    const optsFn = async (req: mixed, res: mixed) => {
       let opts = {
         schema: this.ast,
-        resolvers: await this.rootValue({req}, true)
+        resolvers: await this.rootValue({req, res}, true)
       }
 
       opts.schema = makeExecutableSchema({
@@ -271,7 +271,7 @@ export class GQLExpressMiddleware extends EventEmitter
       if (patchFn && typeof patchFn === 'function') {
         merge(
           opts,
-          (patchFn.bind(this)(opts, {req})) || opts
+          (patchFn.bind(this)(opts, {req, res})) || opts
         );
       }
 


### PR DESCRIPTION
### What
Passing along `res` through to `patchFn` when generating options for `apollo-server`.  

### Why
Without this change, `res` is not available to resolver functions.

![img](https://media1.giphy.com/media/3ohs7YMlUQ6Jk8w0rS/giphy.gif)